### PR TITLE
`<StopWatch>`를 구현한다.

### DIFF
--- a/src/components/stop-watch/stop-watch.stories.tsx
+++ b/src/components/stop-watch/stop-watch.stories.tsx
@@ -1,0 +1,51 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { StopWatch } from './stop-watch';
+
+const meta: Meta<typeof StopWatch> = {
+  component: StopWatch,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof StopWatch>;
+
+export const Example: Story = {
+  render: () => {
+    const roundToTwoDecimalPlaces = (num: number): string => {
+      return num.toFixed(2);
+    };
+
+    return (
+      <StopWatch
+        autoStart
+        interval={16}
+      >
+        {({ currentTime, start, pause, reset, isRunning }) => (
+          <section>
+            <div>
+              <span
+                style={{
+                  marginRight: '0.5rem',
+                }}
+              >
+                {roundToTwoDecimalPlaces(currentTime)}
+              </span>
+              <button
+                type="button"
+                onClick={isRunning ? pause : start}
+              >
+                {isRunning ? 'stop' : 'start'}
+              </button>
+              <button
+                type="button"
+                onClick={reset}
+              >
+                Reset
+              </button>
+            </div>
+          </section>
+        )}
+      </StopWatch>
+    );
+  },
+};

--- a/src/components/stop-watch/stop-watch.stories.tsx
+++ b/src/components/stop-watch/stop-watch.stories.tsx
@@ -16,10 +16,7 @@ export const Example: Story = {
     };
 
     return (
-      <StopWatch
-        autoStart
-        interval={16}
-      >
+      <StopWatch>
         {({ currentTime, start, pause, reset, isRunning }) => (
           <section>
             <div>

--- a/src/components/stop-watch/stop-watch.test.tsx
+++ b/src/components/stop-watch/stop-watch.test.tsx
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { StopWatch } from './stop-watch';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+describe('<StopWatch>', () => {
+  it('<StopWatch> 컴포넌트의 초기 currentTime은 0이다.', () => {
+    const { getByTestId } = render(
+      <StopWatch>
+        {({ currentTime }) => (
+          <span data-testid="current-time">{currentTime}</span>
+        )}
+      </StopWatch>,
+    );
+
+    const currentTime = getByTestId('current-time');
+    expect(currentTime.textContent).toBe('0');
+  });
+
+  it('<StopWatch> 컴포넌트의 start 함수를 호출하면 isRunning이 true가 된다.', async () => {
+    const { getByTestId } = render(
+      <StopWatch>
+        {({ isRunning, start, pause }) => (
+          <button
+            data-testid="stop-watch-button"
+            onClick={isRunning ? pause : start}
+          >
+            {isRunning ? 'pause' : 'start'}
+          </button>
+        )}
+      </StopWatch>,
+    );
+
+    const button = getByTestId('stop-watch-button');
+    expect(button.textContent).toBe('start');
+
+    await userEvent.click(button);
+    expect(button.textContent).toBe('pause');
+
+    await userEvent.click(button);
+    await userEvent.click(button);
+    expect(button.textContent).toBe('pause');
+  });
+
+  it('<StopWatch>가 제공하는 isRunning과 isStopped, isPaused는 상호 배타적이다.', async () => {
+    const { getByTestId } = render(
+      <StopWatch>
+        {({
+          isRunning,
+          isStopped,
+          isPaused,
+          currentTime,
+          start,
+          pause,
+          reset,
+        }) => (
+          <section>
+            <button
+              data-testid="start-button"
+              onClick={start}
+            >
+              Start
+            </button>
+            <button
+              data-testid="pause-button"
+              onClick={pause}
+            >
+              Pause
+            </button>
+            <button
+              data-testid="reset-button"
+              onClick={reset}
+            >
+              Reset
+            </button>
+            <p data-testid="current-time">{currentTime}</p>
+            <div>
+              <span data-testid="is-running">{isRunning ? 'running' : ''}</span>
+              <span data-testid="is-stopped">{isStopped ? 'stopped' : ''}</span>
+              <span data-testid="is-paused">{isPaused ? 'paused' : ''}</span>
+            </div>
+          </section>
+        )}
+      </StopWatch>,
+    );
+
+    const currentTime = getByTestId('current-time');
+    const startButton = getByTestId('start-button');
+    const pauseButton = getByTestId('pause-button');
+    const resetButton = getByTestId('reset-button');
+    const isRunning = getByTestId('is-running');
+    const isStopped = getByTestId('is-stopped');
+    const isPaused = getByTestId('is-paused');
+
+    expect(currentTime.textContent).toBe('0');
+    expect(isRunning.textContent).toBe('');
+    expect(isStopped.textContent).toBe('stopped');
+    expect(isPaused.textContent).toBe('');
+
+    await userEvent.click(startButton);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    expect(currentTime.textContent).not.toBe('0');
+    expect(isRunning.textContent).toBe('running');
+    expect(isStopped.textContent).toBe('');
+    expect(isPaused.textContent).toBe('');
+
+    await userEvent.click(pauseButton);
+    expect(isRunning.textContent).toBe('');
+    expect(isStopped.textContent).toBe('');
+    expect(isPaused.textContent).toBe('paused');
+
+    await userEvent.click(resetButton);
+    expect(currentTime.textContent).toBe('0');
+    expect(isRunning.textContent).toBe('');
+    expect(isStopped.textContent).toBe('stopped');
+    expect(isPaused.textContent).toBe('');
+  });
+});

--- a/src/components/stop-watch/stop-watch.test.tsx
+++ b/src/components/stop-watch/stop-watch.test.tsx
@@ -42,7 +42,7 @@ describe('<StopWatch>', () => {
     expect(button.textContent).toBe('pause');
   });
 
-  it('start를 실', async () => {
+  it('reset을 실행하면, isRunning은 false가 되고, currentTime은 0이 된다.', async () => {
     const { getByTestId } = render(
       <StopWatch>
         {({ isRunning, currentTime, start, pause, reset }) => (
@@ -92,6 +92,11 @@ describe('<StopWatch>', () => {
 
     await userEvent.click(pauseButton);
     expect(isRunning.textContent).toBe('paused');
+
+    await userEvent.click(startButton);
+    expect(isRunning.textContent).toBe('running');
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
 
     await userEvent.click(resetButton);
     expect(currentTime.textContent).toBe('0');

--- a/src/components/stop-watch/stop-watch.test.tsx
+++ b/src/components/stop-watch/stop-watch.test.tsx
@@ -17,7 +17,7 @@ describe('<StopWatch>', () => {
     expect(currentTime.textContent).toBe('0');
   });
 
-  it('<StopWatch> 컴포넌트의 start 함수를 호출하면 isRunning이 true가 된다.', async () => {
+  it('isRunning은 start를 호출하면 true가 되고, pause를 호출하면 false가 된다.', async () => {
     const { getByTestId } = render(
       <StopWatch>
         {({ isRunning, start, pause }) => (
@@ -42,18 +42,10 @@ describe('<StopWatch>', () => {
     expect(button.textContent).toBe('pause');
   });
 
-  it('<StopWatch>가 제공하는 isRunning과 isStopped, isPaused는 상호 배타적이다.', async () => {
+  it('start를 실', async () => {
     const { getByTestId } = render(
       <StopWatch>
-        {({
-          isRunning,
-          isStopped,
-          isPaused,
-          currentTime,
-          start,
-          pause,
-          reset,
-        }) => (
+        {({ isRunning, currentTime, start, pause, reset }) => (
           <section>
             <button
               data-testid="start-button"
@@ -75,9 +67,9 @@ describe('<StopWatch>', () => {
             </button>
             <p data-testid="current-time">{currentTime}</p>
             <div>
-              <span data-testid="is-running">{isRunning ? 'running' : ''}</span>
-              <span data-testid="is-stopped">{isStopped ? 'stopped' : ''}</span>
-              <span data-testid="is-paused">{isPaused ? 'paused' : ''}</span>
+              <span data-testid="is-running">
+                {isRunning ? 'running' : 'paused'}
+              </span>
             </div>
           </section>
         )}
@@ -89,30 +81,20 @@ describe('<StopWatch>', () => {
     const pauseButton = getByTestId('pause-button');
     const resetButton = getByTestId('reset-button');
     const isRunning = getByTestId('is-running');
-    const isStopped = getByTestId('is-stopped');
-    const isPaused = getByTestId('is-paused');
 
     expect(currentTime.textContent).toBe('0');
-    expect(isRunning.textContent).toBe('');
-    expect(isStopped.textContent).toBe('stopped');
-    expect(isPaused.textContent).toBe('');
+    expect(isRunning.textContent).toBe('paused');
 
     await userEvent.click(startButton);
     await new Promise((resolve) => setTimeout(resolve, 1000));
     expect(currentTime.textContent).not.toBe('0');
     expect(isRunning.textContent).toBe('running');
-    expect(isStopped.textContent).toBe('');
-    expect(isPaused.textContent).toBe('');
 
     await userEvent.click(pauseButton);
-    expect(isRunning.textContent).toBe('');
-    expect(isStopped.textContent).toBe('');
-    expect(isPaused.textContent).toBe('paused');
+    expect(isRunning.textContent).toBe('paused');
 
     await userEvent.click(resetButton);
     expect(currentTime.textContent).toBe('0');
-    expect(isRunning.textContent).toBe('');
-    expect(isStopped.textContent).toBe('stopped');
-    expect(isPaused.textContent).toBe('');
+    expect(isRunning.textContent).toBe('paused');
   });
 });

--- a/src/components/stop-watch/stop-watch.tsx
+++ b/src/components/stop-watch/stop-watch.tsx
@@ -4,15 +4,7 @@ import { useInterval } from './use-interval';
 const FRAME_INTERVAL_MS = 1 / 60;
 
 enum StopWatchState {
-  /**
-   * @description 타이머가 시작되었음을 나타내는 상태로 타이머의 시간이 흐른다.
-   */
   Running,
-
-  /**
-   * @description 타이머가 일시정지된 상태로 타이머의 시간은 유지된다.
-   * 사용자가 타이머를 일시정지할 때 이 상태가 된다.
-   */
   Paused,
 }
 

--- a/src/components/stop-watch/stop-watch.tsx
+++ b/src/components/stop-watch/stop-watch.tsx
@@ -86,22 +86,18 @@ function stopWatchReducer(
   }
 }
 
-function useStopWatchReducer(
-  initialTime: number,
-): [StopWatchStateDefinition, (action: StopWatchActions) => void] {
+function useStopWatchReducer(): [
+  StopWatchStateDefinition,
+  (action: StopWatchActions) => void,
+] {
   return useReducer(stopWatchReducer, {
     state: StopWatchState.Stopped,
-    time: initialTime,
+    time: 0,
   });
 }
 
-function useStopWatch(
-  autoStart: boolean,
-  initialTime: number,
-  interval: number,
-) {
-  const [{ state, time: currentTime }, dispatch] =
-    useStopWatchReducer(initialTime);
+function useStopWatch(autoStart: boolean, interval: number) {
+  const [{ state, time: currentTime }, dispatch] = useStopWatchReducer();
 
   const start = useCallback(() => {
     dispatch({
@@ -157,7 +153,6 @@ function useStopWatch(
 interface StopWatchProps {
   autoStart?: boolean;
   interval?: number;
-  initialTime?: number;
   children: (props: {
     isRunning: boolean;
     isStopped: boolean;
@@ -172,7 +167,6 @@ interface StopWatchProps {
 export function StopWatch({
   autoStart = false,
   interval = DEFAULT_INTERVAL_MS,
-  initialTime = 0,
   children,
 }: StopWatchProps): JSX.Element {
   if (interval < MINIMUM_INTERVAL_MS) {
@@ -180,7 +174,7 @@ export function StopWatch({
   }
 
   const { isRunning, isStopped, isPaused, currentTime, start, pause, reset } =
-    useStopWatch(autoStart, initialTime, interval);
+    useStopWatch(autoStart, interval);
 
   return children({
     isRunning,

--- a/src/components/stop-watch/stop-watch.tsx
+++ b/src/components/stop-watch/stop-watch.tsx
@@ -119,7 +119,6 @@ function useStopWatch(autoStart: boolean) {
 
   return {
     isRunning: state === StopWatchState.Running,
-    isPaused: state === StopWatchState.Paused,
     currentTime,
     start,
     pause,
@@ -131,7 +130,6 @@ interface StopWatchProps {
   autoStart?: boolean;
   children: (props: {
     isRunning: boolean;
-    isPaused: boolean;
     currentTime: number;
     start: () => void;
     pause: () => void;
@@ -143,12 +141,11 @@ export function StopWatch({
   autoStart = false,
   children,
 }: StopWatchProps): JSX.Element {
-  const { isRunning, isPaused, currentTime, start, pause, reset } =
+  const { isRunning, currentTime, start, pause, reset } =
     useStopWatch(autoStart);
 
   return children({
     isRunning,
-    isPaused,
     currentTime,
     start,
     pause,

--- a/src/components/stop-watch/stop-watch.tsx
+++ b/src/components/stop-watch/stop-watch.tsx
@@ -1,0 +1,194 @@
+import { useCallback, useEffect, useReducer } from 'react';
+import { useInterval } from './use-interval';
+
+const MINIMUM_INTERVAL_MS = 16;
+const DEFAULT_INTERVAL_MS = 1000;
+
+enum StopWatchState {
+  /**
+   * @description 타이머가 시작되었음을 나타내는 상태로 타이머의 시간이 흐른다.
+   */
+  Running,
+  /**
+   * @description 타이머가 완전히 정지되었음을 나타내는 상태로 타이머의 시간이 0으로 초기화된다.
+   */
+  Stopped,
+  /**
+   * @description 타이머가 일시정지된 상태로 타이머의 시간은 유지된다.
+   * 사용자가 타이머를 일시정지할 때 이 상태가 된다.
+   */
+  Paused,
+}
+
+interface StopWatchStateDefinition {
+  state: StopWatchState;
+  time: number;
+}
+
+enum StopWatchActionTypes {
+  Start,
+  Stop,
+  Pause,
+  Reset,
+  Tick,
+}
+
+type StopWatchActions =
+  | {
+      type: StopWatchActionTypes.Start;
+    }
+  | {
+      type: StopWatchActionTypes.Stop;
+    }
+  | {
+      type: StopWatchActionTypes.Pause;
+    }
+  | {
+      type: StopWatchActionTypes.Reset;
+    }
+  | {
+      type: StopWatchActionTypes.Tick;
+      interval: number;
+    };
+
+function stopWatchReducer(
+  state: StopWatchStateDefinition,
+  action: StopWatchActions,
+): StopWatchStateDefinition {
+  switch (action.type) {
+    case StopWatchActionTypes.Start:
+      return {
+        ...state,
+        state: StopWatchState.Running,
+      };
+    case StopWatchActionTypes.Stop:
+      return {
+        ...state,
+        state: StopWatchState.Stopped,
+      };
+    case StopWatchActionTypes.Pause:
+      return {
+        ...state,
+        state: StopWatchState.Paused,
+      };
+    case StopWatchActionTypes.Reset:
+      return {
+        state: StopWatchState.Stopped,
+        time: 0,
+      };
+    case StopWatchActionTypes.Tick:
+      return {
+        ...state,
+        time: state.time + action.interval / 1000,
+      };
+    default:
+      throw new Error(`Unsupported action type: ${action}`);
+  }
+}
+
+function useStopWatchReducer(
+  initialTime: number,
+): [StopWatchStateDefinition, (action: StopWatchActions) => void] {
+  return useReducer(stopWatchReducer, {
+    state: StopWatchState.Stopped,
+    time: initialTime,
+  });
+}
+
+function useStopWatch(
+  autoStart: boolean,
+  initialTime: number,
+  interval: number,
+) {
+  const [{ state, time: currentTime }, dispatch] =
+    useStopWatchReducer(initialTime);
+
+  const start = useCallback(() => {
+    dispatch({
+      type: StopWatchActionTypes.Start,
+    });
+  }, [dispatch]);
+
+  const pause = useCallback(() => {
+    dispatch({
+      type: StopWatchActionTypes.Pause,
+    });
+  }, [dispatch]);
+
+  const reset = useCallback(() => {
+    dispatch({
+      type: StopWatchActionTypes.Reset,
+    });
+  }, [dispatch]);
+
+  const tick = useCallback(() => {
+    dispatch({
+      type: StopWatchActionTypes.Tick,
+      interval,
+    });
+  }, [dispatch, interval]);
+
+  useEffect(() => {
+    if (autoStart) {
+      start();
+    }
+  }, [autoStart, start]);
+
+  useInterval(
+    () => {
+      if (state === StopWatchState.Running) {
+        tick();
+      }
+    },
+    state === StopWatchState.Running ? interval : null,
+  );
+
+  return {
+    isRunning: state === StopWatchState.Running,
+    isStopped: state === StopWatchState.Stopped,
+    isPaused: state === StopWatchState.Paused,
+    currentTime,
+    start,
+    pause,
+    reset,
+  };
+}
+
+interface StopWatchProps {
+  autoStart?: boolean;
+  interval?: number;
+  initialTime?: number;
+  children: (props: {
+    isRunning: boolean;
+    isStopped: boolean;
+    isPaused: boolean;
+    currentTime: number;
+    start: () => void;
+    pause: () => void;
+    reset: () => void;
+  }) => JSX.Element;
+}
+
+export function StopWatch({
+  autoStart = false,
+  interval = DEFAULT_INTERVAL_MS,
+  initialTime = 0,
+  children,
+}: StopWatchProps): JSX.Element {
+  if (interval < MINIMUM_INTERVAL_MS) {
+    interval = MINIMUM_INTERVAL_MS;
+  }
+
+  const { isRunning, isStopped, isPaused, currentTime, start, pause, reset } =
+    useStopWatch(autoStart, initialTime, interval);
+
+  return children({
+    isRunning,
+    isStopped,
+    isPaused,
+    currentTime,
+    start,
+    pause,
+    reset,
+  });
+}

--- a/src/components/stop-watch/stop-watch.tsx
+++ b/src/components/stop-watch/stop-watch.tsx
@@ -8,10 +8,7 @@ enum StopWatchState {
    * @description 타이머가 시작되었음을 나타내는 상태로 타이머의 시간이 흐른다.
    */
   Running,
-  /**
-   * @description 타이머가 완전히 정지되었음을 나타내는 상태로 타이머의 시간이 0으로 초기화된다.
-   */
-  Stopped,
+
   /**
    * @description 타이머가 일시정지된 상태로 타이머의 시간은 유지된다.
    * 사용자가 타이머를 일시정지할 때 이 상태가 된다.
@@ -37,9 +34,6 @@ type StopWatchActions =
       type: StopWatchActionTypes.Start;
     }
   | {
-      type: StopWatchActionTypes.Stop;
-    }
-  | {
       type: StopWatchActionTypes.Pause;
     }
   | {
@@ -59,11 +53,6 @@ function stopWatchReducer(
         ...state,
         state: StopWatchState.Running,
       };
-    case StopWatchActionTypes.Stop:
-      return {
-        ...state,
-        state: StopWatchState.Stopped,
-      };
     case StopWatchActionTypes.Pause:
       return {
         ...state,
@@ -71,7 +60,7 @@ function stopWatchReducer(
       };
     case StopWatchActionTypes.Reset:
       return {
-        state: StopWatchState.Stopped,
+        state: StopWatchState.Paused,
         time: 0,
       };
     case StopWatchActionTypes.Tick:
@@ -89,7 +78,7 @@ function useStopWatchReducer(): [
   (action: StopWatchActions) => void,
 ] {
   return useReducer(stopWatchReducer, {
-    state: StopWatchState.Stopped,
+    state: StopWatchState.Paused,
     time: 0,
   });
 }
@@ -138,7 +127,6 @@ function useStopWatch(autoStart: boolean) {
 
   return {
     isRunning: state === StopWatchState.Running,
-    isStopped: state === StopWatchState.Stopped,
     isPaused: state === StopWatchState.Paused,
     currentTime,
     start,
@@ -151,7 +139,6 @@ interface StopWatchProps {
   autoStart?: boolean;
   children: (props: {
     isRunning: boolean;
-    isStopped: boolean;
     isPaused: boolean;
     currentTime: number;
     start: () => void;
@@ -164,12 +151,11 @@ export function StopWatch({
   autoStart = false,
   children,
 }: StopWatchProps): JSX.Element {
-  const { isRunning, isStopped, isPaused, currentTime, start, pause, reset } =
+  const { isRunning, isPaused, currentTime, start, pause, reset } =
     useStopWatch(autoStart);
 
   return children({
     isRunning,
-    isStopped,
     isPaused,
     currentTime,
     start,

--- a/src/components/stop-watch/stop-watch.tsx
+++ b/src/components/stop-watch/stop-watch.tsx
@@ -15,7 +15,6 @@ interface StopWatchStateDefinition {
 
 enum StopWatchActionTypes {
   Start,
-  Stop,
   Pause,
   Reset,
   Tick,

--- a/src/components/stop-watch/stop-watch.tsx
+++ b/src/components/stop-watch/stop-watch.tsx
@@ -74,7 +74,15 @@ function useStopWatchReducer(): [
   });
 }
 
-function useStopWatch(autoStart: boolean) {
+interface StopWatchAPI {
+  isRunning: boolean;
+  currentTime: number;
+  start: () => void;
+  pause: () => void;
+  reset: () => void;
+}
+
+function useStopWatch(autoStart: boolean): StopWatchAPI {
   const [{ state, time: currentTime }, dispatch] = useStopWatchReducer();
 
   const start = useCallback(() => {
@@ -127,13 +135,7 @@ function useStopWatch(autoStart: boolean) {
 
 interface StopWatchProps {
   autoStart?: boolean;
-  children: (props: {
-    isRunning: boolean;
-    currentTime: number;
-    start: () => void;
-    pause: () => void;
-    reset: () => void;
-  }) => JSX.Element;
+  children: (props: StopWatchAPI) => JSX.Element;
 }
 
 export function StopWatch({

--- a/src/components/stop-watch/use-interval.ts
+++ b/src/components/stop-watch/use-interval.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react';
+
+type IntervalCallback = () => void;
+
+export function useInterval(callback: IntervalCallback, delay?: number | null) {
+  const savedCallback = useRef<IntervalCallback>(() => {});
+
+  useEffect(() => {
+    savedCallback.current = callback;
+  });
+
+  useEffect(() => {
+    if (delay !== null) {
+      const interval = setInterval(() => {
+        savedCallback.current();
+      }, delay || 0);
+
+      return () => {
+        clearInterval(interval);
+      };
+    }
+
+    return undefined;
+  }, [delay]);
+}


### PR DESCRIPTION
# 관련 이슈

이슈: #15 

# 내용

다음과 같은 내용을 구현했습니다.

- `<StopWatch>`를 구현했습니다.
  - 현실세계의 스톱 워치를 추상화하여 render prop 형식으로 API를 제공하는 선언적인 컴포넌트를 만들어보려고 시도해봤습니다.

# 미리보기

| 내용 | 스크린샷, 비디오, GIF |
| ---- | --------------------- |
| `<StopWatch>` | ![2024-06-151 40 45-ezgif com-video-to-gif-converter](https://github.com/m1nsuplee/ui/assets/75208324/7836ae77-f774-4044-9640-166979cb0837) |
