### PR TITLE
종횡비를 유지하는 `<AspectRatio>`를 구현한다.

### DIFF
--- a/src/components/aspect-ratio/aspect-ratio.stories.tsx
+++ b/src/components/aspect-ratio/aspect-ratio.stories.tsx
@@ -1,0 +1,37 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { AspectRatio } from './aspect-ratio';
+
+const meta: Meta<typeof AspectRatio> = {
+  component: AspectRatio,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AspectRatio>;
+
+export const Example: Story = {
+  render: () => {
+    return (
+      <div
+        style={{
+          width: '200px',
+        }}
+      >
+        <AspectRatio
+          ratio={16 / 9}
+          as="article"
+        >
+          <img
+            src="https://picsum.photos/seed/picsum/200/200"
+            alt="Random"
+            style={{
+              width: '100%',
+              height: '100%',
+              objectFit: 'cover',
+            }}
+          />
+        </AspectRatio>
+      </div>
+    );
+  },
+};

--- a/src/components/aspect-ratio/aspect-ratio.tsx
+++ b/src/components/aspect-ratio/aspect-ratio.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { ElementType, forwardRef } from 'react';
 import {
   PolymorphicComponentProps,
   PolymorphicComponentType,
@@ -12,7 +12,7 @@ interface AspectRatioProps {
 type AspectRatioComponentType = PolymorphicComponentType<AspectRatioProps>;
 
 export const AspectRatio: AspectRatioComponentType = forwardRef(
-  function AspectRatioWithRef<C extends React.ElementType = 'div'>(
+  function AspectRatioWithRef<C extends ElementType = 'div'>(
     props: PolymorphicComponentProps<C> & AspectRatioProps,
     ref?: PolymorphicRef<C>,
   ) {

--- a/src/components/aspect-ratio/aspect-ratio.tsx
+++ b/src/components/aspect-ratio/aspect-ratio.tsx
@@ -1,0 +1,46 @@
+import { forwardRef } from 'react';
+import {
+  PolymorphicComponentProps,
+  PolymorphicComponentType,
+  PolymorphicRef,
+} from 'types';
+
+interface AspectRatioProps {
+  ratio?: number;
+}
+
+type AspectRatioComponentType = PolymorphicComponentType<AspectRatioProps>;
+
+export const AspectRatio: AspectRatioComponentType = forwardRef(
+  function AspectRatioWithRef<C extends React.ElementType = 'div'>(
+    props: PolymorphicComponentProps<C> & AspectRatioProps,
+    ref?: PolymorphicRef<C>,
+  ) {
+    const { as, ratio = 1 / 1, style, ...rest } = props;
+
+    const Component = as || 'div';
+
+    return (
+      <div
+        style={{
+          position: 'relative',
+          width: '100%',
+          paddingBottom: `${100 / ratio}%`,
+        }}
+      >
+        <Component
+          {...rest}
+          ref={ref}
+          style={{
+            ...style,
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0,
+          }}
+        />
+      </div>
+    );
+  },
+);


### PR DESCRIPTION
`AspectRatio` 컴포넌트는 자식 요소의 비율을 유지하면서 반응형 컨테이너를 제공합니다. 이 컴포넌트는 이미지, 비디오, 지도 등 특정 종횡비를 유지해야 하는 콘텐츠에 유용합니다.

| Prop | Description |
| ---- | --------------------- |
| `as` | 태그를 결정합니다. |
| `ratio` | 종횡비를 결정합니다. |

